### PR TITLE
update tests, increment version for tagging

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "c41e01d8-14e5-11ea-185b-e7eabed7be4b"
 keywords = ["log", "rotate", "roller", "logrotate"]
 license = "MIT"
 authors = ["Tanmay Mohapatra <tanmaykm@gmail.com>"]
-version = "0.4.3"
+version = "0.4.4"
 
 [compat]
 julia = "1.2"

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Constructor parameters in addition to those for `RollingFileWriter`:
 - `logger`: instance of AbstractLogger to tee log entries to
 - `assumed_level`: level of the log messages to assume (default Info)
 
+Note: `RollingFileWriterTee` is supported only until Julia 1.7.
 
 ## `RollingLogger`
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -192,9 +192,12 @@ function test_process_streams()
         @test isfile(rolledfile(filepath, 1))
         @test !isfile(rolledfile(filepath, 2))
 
-        @test io.procstream !== nothing
-        @test io.procstreamer !== nothing
-        @test !istaskdone(io.procstreamer)
+        if VERSION < v"1.8"
+            # pipelined processes are handled differently in Julia 1.8 and later
+            @test io.procstream !== nothing
+            @test io.procstreamer !== nothing
+            @test !istaskdone(io.procstreamer)
+        end
 
         close(io)
         @test io.procstream === nothing
@@ -475,9 +478,14 @@ end
 @testset "file writer" begin
     test_filewriter()
 end
-@testset "pipelined tee" begin
-    test_pipelined_tee()
+
+if VERSION < v"1.8"
+    # pipelined tee logger is available only on Julia 1.7 and earlier
+    @testset "pipelined tee" begin
+        test_pipelined_tee()
+    end
 end
+
 @testset "process streams" begin
     test_process_streams()
 end


### PR DESCRIPTION
Updated tests, removed tee logger tests for Julia 1.8 onwards. Julia pipelining internals have changed in ways that make the current implementation break. Also with better tee logging support via other means, planning to drop this feature in the next version.